### PR TITLE
Fix the computation of fromForeignPtr, less segfaults, more smiles

### DIFF
--- a/Core/Array/Unboxed.hs
+++ b/Core/Array/Unboxed.hs
@@ -219,7 +219,8 @@ fromForeignPtr :: PrimType ty
                => (ForeignPtr ty, Int, Int) -- ForeignPtr, an offset in prim elements, a size in prim elements
                -> UArray ty
 fromForeignPtr (fptr, 0, I# len) = UVecAddr len (toFinalPtrForeign fptr)
-fromForeignPtr (fptr, ofs, I# len) = UVecSlice ofs (I# len) (UVecAddr len (toFinalPtrForeign fptr))
+fromForeignPtr (fptr, ofs, len) =
+  let !(I# l) = len + ofs in UVecSlice ofs (I# l) (UVecAddr l (toFinalPtrForeign fptr))
 
 -- | return the number of elements of the array.
 length :: PrimType ty => UArray ty -> Int


### PR DESCRIPTION
If there is a length and an offset the end position is the offset plus length, so fix that.

As a side note, using explicit `Int#` in `UVectorAddr` is a pain, and probably doesn't buy anything over `{-# UNPACK #-} !Int` anyway.